### PR TITLE
Merge feat/wporg-pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.rsa
+*.rsa.pub

--- a/pipelines/wporg.yaml
+++ b/pipelines/wporg.yaml
@@ -1,0 +1,47 @@
+name: Pull plugin/theme archives from WordPress.org
+
+needs:
+  packages:
+    - unzip
+
+inputs:
+  expected-sha256:
+    description: |
+      The expected SHA256 of the downloaded artifact.
+  
+  slug:
+    description: |
+      The package's WordPress.org slug.
+    default: ${{package.name}}
+
+  version:
+    description: |
+      The package version to download.
+    default: ${{package.version}}
+  
+  type:
+    description: |
+      The package type ("plugin", "theme") to use.
+    default: plugin
+
+  destination:
+    description: |
+      The location to install the package.
+    default: ""
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://downloads.wordpress.org/${{inputs.type}}/${{inputs.slug}}.${{inputs.version}}.zip
+      expected-sha256: ${{inputs.expected-sha256}}
+      purl-name: ${{inputs.slug}}
+      purl-version: ${{inputs.version}}
+      extract: false
+  - runs: |
+      set -ex
+      dest='${{inputs.destination}}'
+      if [ -z "$dest" ]; then
+        dest='${{targets.destdir}}/usr/src/wordpress/wp-content/${{inputs.type}}s/'
+      fi
+      mkdir -p $dest
+      unzip ${{inputs.slug}}.${{inputs.version}}.zip -d $dest

--- a/pipelines/wporg.yaml
+++ b/pipelines/wporg.yaml
@@ -2,10 +2,11 @@ name: Pull plugin/theme archives from WordPress.org
 
 needs:
   packages:
+    - busybox
     - unzip
 
 inputs:
-  expected-sha256:
+  sha256:
     description: |
       The expected SHA256 of the downloaded artifact.
   
@@ -22,7 +23,7 @@ inputs:
   type:
     description: |
       The package type ("plugin", "theme") to use.
-    default: plugin
+    default: "plugin"
 
   destination:
     description: |
@@ -32,8 +33,8 @@ inputs:
 pipeline:
   - uses: fetch
     with:
-      uri: https://downloads.wordpress.org/${{inputs.type}}/${{inputs.slug}}.${{inputs.version}}.zip
-      expected-sha256: ${{inputs.expected-sha256}}
+      uri: "https://downloads.wordpress.org/${{inputs.type}}/${{inputs.slug}}.${{inputs.version}}.zip"
+      expected-sha256: ${{inputs.sha256}}
       purl-name: ${{inputs.slug}}
       purl-version: ${{inputs.version}}
       extract: false


### PR DESCRIPTION
Improves individual package clarity by replacing repeated `fetch`/`run` pipelines with custom `wporg` pipeline, significantly reducing code reuse for packages imported from WordPress.org plugin/theme repos.